### PR TITLE
create multiple jokes and set state

### DIFF
--- a/src/JokeList.js
+++ b/src/JokeList.js
@@ -2,12 +2,24 @@ import React, {Component} from "react";
 import axios from "axios";
 
 class JokeList extends Component {
+    static defaultProps = {
+        numJokesToGet: 10
+    };
+    constructor(props) {
+        super(props);
+        this.state = { jokes: [] }
+    };
+
     async componentDidMount() {
-        // load jokes
-        let res = await axios.get("https://icanhazdadjoke.com/", {
-            headers: { Accept : "application/json" }
-        });
-        console.log(res.data.joke);
+        let jokes = [];
+        while(jokes.length < this.props.numJokesToGet) {
+            // load jokes
+            let res = await axios.get("https://icanhazdadjoke.com/", {
+                headers: { Accept : "application/json" }
+            });
+            jokes.push(res.data.joke);
+        }
+        this.setState({ jokes : jokes});
     }
     render() {
         return (


### PR DESCRIPTION
This allows us to request multiple jokes, then set the state with those jokes.
In `JokeList.js`, a `defaultProps` is set to 10 as a limit to our number of jokes.  Also, the `state` is initialized, with 'jokes' equal to an empty array.  Then, inside of `componentDidMount`, a variable is created called 'jokes' to store all 10 jokes to then be used to set state once.  A `while` loop is used, to then loop over the API request and retrieve the 10 jokes.  The response of `res.data.joke` is then set to be pushed into the empty jokes array with `jokes.push`.  The `console.log` is removed. Then, `setState` is used, where our `jokes` array inside the `componentDidMount` is set to equal the `jokes` array inside the `state` itself.