### PR TITLE
add styles and elements to JokeList Component

### DIFF
--- a/src/JokeList.css
+++ b/src/JokeList.css
@@ -1,0 +1,47 @@
+.JokeList {
+    display: flex;
+    width: 80%;
+    height: 80%;
+}
+
+.JokeList-sidebar {
+    background: #9575cd;
+    display: flex;
+    flex-flow: column;
+    align-items: center;
+    justify-content: center;
+    width: 30%;
+    text-align: center;
+    box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.1),
+    inset 0 0 25px #7e57c2; 
+    z-index: 2;
+}
+
+.JokeList-sidebar img {
+    width: 50%;
+    border-radius: 50%;
+    box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.1);
+}
+
+.JokeList-title {
+    font-size: 4rem;
+    margin: 2rem;
+    color: #fff;
+    font-weight: 300;
+    letter-spacing: 0.6rem;
+}
+
+.JokeList-title span {
+    font-weight: 700;
+    letter-spacing: 0;
+    white-space: nowrap;
+}
+
+.JokeList-jokes {
+    background: #fff;
+    height: 90%;
+    align-self: center;
+    width: 70%;
+    overflow: scroll;
+    box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.1);
+}

--- a/src/JokeList.js
+++ b/src/JokeList.js
@@ -1,5 +1,6 @@
 import React, {Component} from "react";
 import axios from "axios";
+import "./JokeList.css";
 
 class JokeList extends Component {
     static defaultProps = {
@@ -24,7 +25,11 @@ class JokeList extends Component {
     render() {
         return (
             <div className="JokeList">
-                <h1>Chee-Z-Jokes</h1>
+                <div className="JokeList-sidebar">
+                    <h1 className="JokeList-title"><span>Chee-Z</span> Jokes</h1>
+                    <img src='https://assets.dryicons.com/uploads/icon/svg/8927/0eb14c71-38f2-433a-bfc8-23d9c99b3647.svg' alt="Laughing emoji" />
+                    <button className="JokeList-getmore">New Jokes</button>
+                </div>                
                 <div className="JokeList-jokes">
                     {this.state.jokes.map(j => (
                         <div>{j}</div>


### PR DESCRIPTION
This adds styles to the `JokeList` component, as well as as some elements.

In `JokeList.js`, another `<div>` is added to the `render` that is for the sidebar, and it's given the class `JokeList-sidebar`.  Also, a class is given for the title, with the name `JokeList-title`.   A `<span>` is put around the first word of the app title for styling purposes.  An image is added to the sidebar of a laughing emoji.  A button is also added with the text of "Get More" to later retrieve more jokes, and this element is given a class of `JokeList-getmore`.  At the top of the component, it is set to `import` the file `JokeList.css`, which was created next.

A new file named `JokeList.css` is created.  For the `JokeList` component itself, it is set to display as a `flex` item to allow the sidebar next to the joke list.  It is also sized appropriately.  For the `JokeList-sidebar`, it is also set to display as `flex` to allow it to display in a column and to center it.  It's width is set as 30% of the `flex` container.  It is given a `box-shadow`, as well as adjusting the `z-index` to keep the shadow over the top of the joke list.  The image is given a `box-shadow` as well, and is provided a `border-radius` to make it a circled shadow behind the image.  The `JokeList-title` is then given a font size, as well as color and spacing.  The `span` inside the title is then given a heavier `font-weight`, its own spacing, and the `white-space` is set so the word does not break.  In the `JokeList-jokes`, it is centered and given a size and background.  It's also given a `box-shadow`, and is given a `scroll` for use later with the joke list.