### PR TITLE
adjust JokeList.js to make each joke an object in state

### DIFF
--- a/src/JokeList.js
+++ b/src/JokeList.js
@@ -18,9 +18,9 @@ class JokeList extends Component {
             let res = await axios.get("https://icanhazdadjoke.com/", {
                 headers: { Accept : "application/json" }
             });
-            jokes.push(res.data.joke);
+            jokes.push({joke: res.data.joke, votes: 0 });
         }
-        this.setState({ jokes : jokes});
+        this.setState({ jokes : jokes });
     }
     render() {
         return (
@@ -32,7 +32,7 @@ class JokeList extends Component {
                 </div>                
                 <div className="JokeList-jokes">
                     {this.state.jokes.map(j => (
-                        <div>{j}</div>
+                        <div>{j.joke} - {j.votes}</div>
                         ))}
                 </div>
             </div>


### PR DESCRIPTION
This adjusts the code in `JokeList.js` so that each joke will now be an object instead of a string.  This will allow us to later add things in like vote for jokes and give them ids eventually.

The `jokes.push` is updated to push in an object with a "joke" and "votes".  The "votes" are set to 0 for now.  Then in the `render`, since its now an object, we adjust it to return `j.joke` as well as `j.votes`. 