### PR TITLE
create Joke Component for each joke with vote arrows

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,12 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;700&display=swap" rel="stylesheet">
+    <link
+      rel="stylesheet"
+      href="https://use.fontawesome.com/releases/v5.7.1/css/all.css"
+      integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr"
+      crossorigin="anonymous"
+    />
     <title>CheeZJokes-React</title>
   </head>
   <body>

--- a/src/Joke.js
+++ b/src/Joke.js
@@ -1,0 +1,19 @@
+import React, {Component} from 'react';
+
+class Joke extends Component {
+    render() {
+        return (
+            <div className="Joke">
+                <div className="Joke-buttons">
+                    <i className="fas fa-arrow-up"></i>
+                    <span>{ this.props.votes }</span>
+                    <i className="fas fa-arrow-down"></i>
+                </div>
+                <div className="Joke-text">{ this.props.text }</div>
+            </div>
+        )
+    }
+}
+
+export default Joke;
+

--- a/src/JokeList.js
+++ b/src/JokeList.js
@@ -1,4 +1,5 @@
 import React, {Component} from "react";
+import Joke from "./Joke";
 import axios from "axios";
 import "./JokeList.css";
 
@@ -18,7 +19,7 @@ class JokeList extends Component {
             let res = await axios.get("https://icanhazdadjoke.com/", {
                 headers: { Accept : "application/json" }
             });
-            jokes.push({joke: res.data.joke, votes: 0 });
+            jokes.push({text: res.data.joke, votes: 0 });
         }
         this.setState({ jokes : jokes });
     }
@@ -32,8 +33,8 @@ class JokeList extends Component {
                 </div>                
                 <div className="JokeList-jokes">
                     {this.state.jokes.map(j => (
-                        <div>{j.joke} - {j.votes}</div>
-                        ))}
+                        <Joke votes={j.votes} text={j.text} />
+                    ))}
                 </div>
             </div>
         );


### PR DESCRIPTION
This creates a new Joke Component with the file name `Joke.js`.  This renders single jokes with vote arrows and number of votes displayed.

In `Joke.js`, it is set to `export` the component.  Inside the `render`, the full `<div>` is given the class name of `Joke`.  Another `<div>` is then added for the arrow buttons, with the class name of `Joke-buttons`. In order to add arrows, over in `index.html` it is linked to "Font Awesome" so we have access to those icons.  In `Joke.js`, it is set with two icons, one for an arrow up and one for arrow down.  In between the two arrow, a `<span>` is used to display the `votes` prop.  Then another `<div>` is added under the buttons to display each actual joke.  This is given a class name of `Joke-text`.
Now in the JokeList Component, in the file `JokeList.js`, the `Joke` Component is imported at the top.  In the `render`, it is now set to `map` to a `Joke` Component from the `state`, with each one given props.  Each has two props passed in.  The prop of `vote` is set to display that from the `state`, and the prop of `text` is set to display that from the `state` as well.  Also, an adjustment is made in the name of the key assigned to the joke retrieved from the API.  It is given the same key name in the render of `text`.