### PR TITLE
style each of the jokes from Joke Component

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -31,6 +31,7 @@
       integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr"
       crossorigin="anonymous"
     />
+    <link href="https://afeld.github.io/emoji-css/emoji.css" rel="stylesheet" />
     <title>CheeZJokes-React</title>
   </head>
   <body>

--- a/src/Joke.css
+++ b/src/Joke.css
@@ -1,0 +1,46 @@
+.Joke {
+    display: flex;
+    border-bottom: 2px solid #eeeeee;
+    justify-content: center;
+    align-items: center;
+    font-weight: 400;
+    /* padding: 1rem; */
+}
+
+.Joke-buttons {
+    display: flex;
+    margin-right: 1rem;
+    justify-content: center;
+    align-items: center;
+    width: 25%;
+}
+
+.Joke-text {
+    width: 75%;
+    font-size: 1rem;
+}
+
+.Joke-votes {
+    width: 50px;
+    height: 50px;
+    line-height: 50px;
+    border-radius: 50%;
+    border: 3px solid red;
+    text-align: center;
+    font-size: 20px;
+    font-weight: 300;
+    box-shadow: 0 10px 38px rgba(0, 0, 0, 0.2), 0 10px 12px rgba(0, 0, 0, 0.1); 
+}
+
+.fa-arrow-up, .fa-arrow-down {
+    font-size: 1.5em;
+    margin: 10px;
+    cursor: pointer;
+}
+
+.Joke-smiley {
+    font-size: 2rem;
+    margin-left: auto;
+    border-radius: 50%;
+    box-shadow: 0 10px 38px rgba(0, 0, 0, 0.2), 0 10px 12px rgba(0, 0, 0, 0.1); 
+}

--- a/src/Joke.js
+++ b/src/Joke.js
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import './Joke.css';
 
 class Joke extends Component {
     render() {
@@ -6,10 +7,13 @@ class Joke extends Component {
             <div className="Joke">
                 <div className="Joke-buttons">
                     <i className="fas fa-arrow-up" onClick={this.props.upvote} />
-                    <span>{ this.props.votes }</span>
+                    <span className="Joke-votes">{ this.props.votes }</span>
                     <i className="fas fa-arrow-down" onClick={this.props.downvote} />
                 </div>
                 <div className="Joke-text">{ this.props.text }</div>
+                <div className="Joke-smiley">
+                    <i className="em em-rolling_on_the_floor_laughing" />
+                </div>
             </div>
         )
     }


### PR DESCRIPTION
This styles each of the jokes coming from the `Joke` Component.
A new file `Joke.css` is created, and it is set to `import` in the file `Joke.js`.  In `Joke.css`, the class of `Joke` itself is set to display as a flexbox item, and is then centered.  It is also given a border and font weight.  Then the joke buttons, with the class of `Joke-buttons`, is also set to display as a flexbox item, and is centered as well.  It's also given a width of 15%.  For the `Joke-text`, it is given a set width of 75% and given a font size also.  
In `Joke.js`, a class was added to the `span` containing the votes for each joke.  Then back in `Joke.css`, it is given a width, height, and line height of 50px.  For a circle border, it's given a `border-radius` of 50%, and a hard-coded border of red for now.  Also it's given a font weight and font size, as well as having the text centered.  Also a `box-shadow` is given.  The Font Awesome arrow up and down, with class names `fa-arrow-up` and `fa-arrow-down` are given a font size, margin, and a cursor of `pointer`.  

To add the emoji's to each joke, a library is used called "Emoji CSS". The link to the library is first added to the `index.html` file.  In the file `Joke.js`, another `div` is added after the joke text.  This is given a class name of `Joke-smiley`.  Then inside of that an icon showing an emoji that is laughing with the name `em em-rolling_on_the_floor_laughing`. 