### PR TITLE
synching the jokes with localStorage to retrieve later

### DIFF
--- a/src/JokeList.js
+++ b/src/JokeList.js
@@ -10,10 +10,14 @@ class JokeList extends Component {
     };
     constructor(props) {
         super(props);
-        this.state = { jokes: [] }
-    };
+        this.state = { jokes: JSON.parse(window.localStorage.getItem("jokes") || "[]") };
+    }
 
-    async componentDidMount() {
+    componentDidMount() {
+        if (this.state.jokes.length === 0) this.getJokes();        
+    }
+
+    async getJokes() {
         let jokes = [];
         while(jokes.length < this.props.numJokesToGet) {
             // load jokes
@@ -23,6 +27,8 @@ class JokeList extends Component {
             jokes.push({ id: uuidv4(), text: res.data.joke, votes: 0 });
         }
         this.setState({ jokes : jokes });
+        window.localStorage.setItem("jokes", JSON.stringify(jokes)
+        );
     }
 
     handleVote(id, delta) {


### PR DESCRIPTION
This allows the jokes to be synched with `localStorage` in the window object, to be retrieved later when they're loaded.

In the `JokeList.js` file, the code under the `componentDidMount` is moved out to it's own method called `getJokes()`.  Inside here the `window.localStorage` is set to where the `jokes` are set to convert to the value of a string with `JSON.stringify`.  Now in the `componentDidMount` an `if` statement is added to check if there are no jokes in the state.  If this is true, then the method `getJokes()` is ran to get new jokes.  In the `state`, `jokes` are set to now equal either the `parsed` version of the  existing jokes stored in `localStorage` or the parsed version of an empty array.