### PR TITLE
preventing duplicate jokes from being added to list

### DIFF
--- a/src/JokeList.js
+++ b/src/JokeList.js
@@ -14,6 +14,8 @@ class JokeList extends Component {
             jokes: JSON.parse(window.localStorage.getItem("jokes") || "[]"),
             loading: false
          };
+        this.seenJokes = new Set(this.state.jokes.map(j => j.text));
+        console.log(this.seenJokes);
         this.handleClick = this.handleClick.bind(this);
     }
 
@@ -28,7 +30,13 @@ class JokeList extends Component {
             let res = await axios.get("https://icanhazdadjoke.com/", {
                 headers: { Accept : "application/json" }
             });
-            jokes.push({ id: uuidv4(), text: res.data.joke, votes: 0 });
+            const newJoke = res.data.joke;
+            if (!this.seenJokes.has(newJoke)) {
+                jokes.push({ id: uuidv4(), text: newJoke, votes: 0 });
+            } else {
+                console.log("FOUND A DUPLICATE!");
+                console.log(newJoke);
+            }
         }
         this.setState( st=> ({
             loading: false,


### PR DESCRIPTION
This prevents a duplicate joke from being added to the list of jokes, if a duplicate is found.

In `JokeList.js`, a new `Set` is created in the constructor to loop over the existing jokes called `seenJokes`.  It is made to iterate over the text only in the joke, by using `map`.
Then in the `getJokes()` method, where the API call is, a new variable is created called `newJoke` to equal the response coming back from the API call.  Then an `if` statement is made, where it loops over the `seenJokes`.  If it does NOT find the `newJoke` in the set, then it is pushed into the joke list.  Otherwise, it is simply not added, and for now is logged in the console.