### PR TITLE
error message if api fails to retrieve jokes

### DIFF
--- a/src/JokeList.js
+++ b/src/JokeList.js
@@ -24,27 +24,34 @@ class JokeList extends Component {
     }
 
     async getJokes() {
-        let jokes = [];
-        while(jokes.length < this.props.numJokesToGet) {
-            // load jokes
-            let res = await axios.get("https://icanhazdadjoke.com/", {
-                headers: { Accept : "application/json" }
-            });
-            const newJoke = res.data.joke;
-            if (!this.seenJokes.has(newJoke)) {
-                jokes.push({ id: uuidv4(), text: newJoke, votes: 0 });
-            } else {
-                console.log("FOUND A DUPLICATE!");
-                console.log(newJoke);
+        try {
+            let jokes = [];
+            while(jokes.length < this.props.numJokesToGet) {
+                // load jokes
+                let res = await axios.get("https://icanhazdadjoke.com/", {
+                    headers: { Accept : "application/json" }
+                });
+                const newJoke = res.data.joke;
+                if (!this.seenJokes.has(newJoke)) {
+                    jokes.push({ id: uuidv4(), text: newJoke, votes: 0 });
+                } else {
+                    console.log("FOUND A DUPLICATE!");
+                    console.log(newJoke);
+                }
             }
+            this.setState( st=> ({
+                loading: false,
+                jokes : [...st.jokes, ...jokes] 
+            }), 
+            () => 
+                window.localStorage.setItem("jokes", JSON.stringify(this.state.jokes))
+            );
         }
-        this.setState( st=> ({
-            loading: false,
-            jokes : [...st.jokes, ...jokes] 
-        }), 
-        () => 
-            window.localStorage.setItem("jokes", JSON.stringify(this.state.jokes))
-        );
+        catch(e) {
+            alert(e);    
+            alert(e + "\n\nUnable to access new jokes. I wish this were a joke too.  :(  \nTry again!");
+            this.setState({ loading: false });
+        }
     }
 
     handleVote(id, delta) {


### PR DESCRIPTION
This will display an error message if the app is unable to connect to the api successfully, to retrieve new jokes.

In `JokeList.js`, in the `getJokes` method,  a `try` is used to run this entire method.  If the API is unable to connect for any reason, then a `catch` is used.  This will then alert the user with an alert box.  This alert box contains the error itself, as well as a message to let the user know what is going on, and to try again.  Also, the user is taken back to the list of jokes.  This is done in `setState` by having `loading` set to `false`.  