### PR TITLE
add styles to the new jokes button

### DIFF
--- a/src/JokeList.css
+++ b/src/JokeList.css
@@ -50,3 +50,31 @@
     color: white;
     text-align: center;
 }
+
+.JokeList-getmore {
+    font-size: 1.5rem;
+    width: 65%;
+    border-radius: 2rem;
+    padding: 1rem 2rem;
+    color: #eee;
+    font-weight: 700;
+    margin: 2rem;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    transition: 0.5s cubic-bezier(0.2, 1, 0.2, 1);
+    text-shadow: 4px 4px 20px black;
+    background: linear-gradient(
+        135deg,
+        rgba(179, 229, 252, 1) 0%,
+        rgba(179, 229, 252, 1) 50%,
+        rgba(240, 98, 146, 1) 50%,
+        rgba(240, 98, 146, 1) 100%
+    );
+    box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.1);
+}
+
+.JokeList-getmore:hover {
+    box-shadow: 0 15px 30px rgba(0, 0, 0, 0.25);
+    transform: translateY(-2px);
+}


### PR DESCRIPTION
Styles are added to the new jokes button.

In the `JokeList.css` file, the class of `JokeList-getmore` is provided multiple styles for fonts, size, spacing, and color. It is given a border radius and a cursor.  Also, the background is given the same `linear-gradient` that was used for the main background. A `box-shadow` is used as well. Then a `hover`is given with a different `box-shadow` and a `transform` to shift it some, and a `transition` is used with a `cubic-bezier`.