### PR TITLE
add responsive styles to app

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,8 @@
 .App {
   display: flex;
-  align-items: center;
   justify-content: center;
-  height: 100vh;
+  padding-top: 15px;
+  height: auto;
   font-family: 'Rubik', sans-serif;
   color: #78909c;
   background: linear-gradient(
@@ -12,4 +12,12 @@
     rgba(240, 98, 146, 1) 50%,
     rgba(240, 98, 146, 1) 100%
   );
+}
+
+@media only screen and (min-width: 950px) {
+  .App {
+    align-items: center;
+    padding-top: 0;
+    height: 100vh;
+  }
 }

--- a/src/Joke.css
+++ b/src/Joke.css
@@ -1,23 +1,47 @@
 .Joke {
-    display: flex;
+    display: block;
     border-bottom: 2px solid #eeeeee;
-    justify-content: center;
+    padding: .5rem;
     align-items: center;
     font-weight: 400;
     /* padding: 1rem; */
 }
 
+@media only screen and (min-width: 950px) {
+    .Joke {
+        display: flex;
+        justify-content: center;
+        padding: 1rem;
+    }
+}
+
 .Joke-buttons {
     display: flex;
-    margin-right: 1rem;
     justify-content: center;
     align-items: center;
-    width: 25%;
+    width: 100%;
+}
+
+@media only screen and (min-width: 950px) {
+    .Joke-buttons {
+        margin-right: 1rem;
+        width: 25%;
+    }
 }
 
 .Joke-text {
-    width: 75%;
+    width: 100%;
     font-size: 1rem;
+    text-align: center;
+    margin: 7px;
+}
+
+@media only screen and (min-width: 950px) {
+    .Joke-text {
+        width: 75%;
+        text-align: inherit;
+        margin: 0;
+    }
 }
 
 .Joke-votes {
@@ -81,9 +105,19 @@
 
 .Joke-smiley {
     font-size: 2rem;
-    margin-left: auto;
     border-radius: 50%;
-    box-shadow: 0 10px 38px rgba(0, 0, 0, 0.2), 0 10px 12px rgba(0, 0, 0, 0.1); 
+    margin: 0 auto;
+    width: 48px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2), 0 4px 8px rgba(0, 0, 0, 0.1); 
+}
+
+@media only screen and (min-width: 950px) {
+    .Joke-smiley {
+        /* margin-left: auto; */
+        margin: 0 0 0 auto;
+        width: auto;
+        box-shadow: 0 10px 38px rgba(0, 0, 0, 0.2), 0 10px 12px rgba(0, 0, 0, 0.1);
+    }
 }
 
 .Joke-smiley:hover {

--- a/src/JokeList.css
+++ b/src/JokeList.css
@@ -1,7 +1,14 @@
 .JokeList {
-    display: flex;
-    width: 80%;
+    display: block;
+    width: 90%;
     height: 80%;
+}
+
+@media only screen and (min-width: 950px) {
+    .JokeList {
+        display: flex;
+        width: 80%;
+    }
 }
 
 .JokeList-sidebar {
@@ -10,11 +17,17 @@
     flex-flow: column;
     align-items: center;
     justify-content: center;
-    width: 30%;
+    width: 100%;
     text-align: center;
     box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.1),
     inset 0 0 25px #7e57c2; 
     z-index: 2;
+}
+
+@media only screen and (min-width: 950px) {
+    .JokeList-sidebar {
+        width: 30%;
+    }
 }
 
 .JokeList-sidebar img {
@@ -38,6 +51,18 @@
     letter-spacing: 0.6rem;
 }
 
+@media only screen and (min-width: 950px) {
+    .JokeList-title {
+        font-size: 3rem;
+    }
+}
+
+@media only screen and (min-width: 1024px) {
+    .JokeList-title {
+        font-size: 4rem;
+    }
+}
+
 .JokeList-title span {
     font-weight: 700;
     letter-spacing: 0;
@@ -46,11 +71,18 @@
 
 .JokeList-jokes {
     background: #fff;
-    height: 90%;
+    height: 87vh;
     align-self: center;
-    width: 70%;
+    width: 100%;
     overflow: scroll;
     box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.1);
+}
+
+@media only screen and (min-width: 950px) {
+    .JokeList-jokes {
+        height: 90%;
+        width: 70%;
+    }
 }
 
 .JokeList-spinner {

--- a/src/JokeList.js
+++ b/src/JokeList.js
@@ -15,7 +15,7 @@ class JokeList extends Component {
             loading: false
          };
         this.seenJokes = new Set(this.state.jokes.map(j => j.text));
-        console.log(this.seenJokes);
+        // console.log(this.seenJokes);
         this.handleClick = this.handleClick.bind(this);
     }
 


### PR DESCRIPTION
This add styles to the entire application to make it useable and properly styled in mobile as well.

In `App.css`, mobile styles are added.  The height was changed to `auto` and it was given some padding at the top.  Also, the aligning of the `flex` items to center is removed in mobile.  A breakpoint of 950px is used for the desktop size.

In `Joke.css`, mobile styles are added.  For the `Joke` class, it's display is changed to `block`, and it's also given a little padding.  The same breakpoint is used for desktop.  For the `Joke-buttons` class, the right margin as well as width is removed.  The same breakpoint is used for desktop.  The `Joke-text` class has the width changed to 100%.  Also the text is centered, and it's given a small margin.  The same breakpoint is used for desktop.   The `Joke-smiley` class is given a margin to center it automatically, and a width of 48px.  The `box-shadow` is also adjusted some.  The same breakpoint is used for desktop. 

In `JokeList.css`, mobile styles are added.  For the `JokeList` class, the width is slightly increased, and the display is changed to `block`.  The same breakpoint is used for desktop.  For the `.JokeList-sidebar` class, the width is increased to 100%.  The same breakpoint is used for desktop.  The image for this class is has the font size slightly decreased at the same breakpoint to 3rem, but is then increased to 4rem at a breakpoint of 1024px.  In the `.JokeList-jokes` class, the height is specified to be `87vh`, and the width is increased to 100%.  The same breakpoint is used for desktop. 

In `JokeList.js`, a minor change is in the `constructor` to remove a `console.log`.